### PR TITLE
Update README.md - fix dependency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ In your `Nargo.toml` file, add the following dependency:
 
 ```toml
 [dependencies]
-noir_bigint = { tag = "v0.1.0", git = "https://github.com/shuklaayush/noir-bigint" }
+noir_bigint_curves = { tag = "v0.1.0", git = "https://github.com/shuklaayush/noir-bigint", directory="crates/curves" }
+noir_biguint = { tag = "v0.1.0", git = "https://github.com/shuklaayush/noir-bigint", directory="crates/biguint" }
+noir_bigint_primefield = { tag = "v0.1.0", git = "https://github.com/shuklaayush/noir-bigint", directory="crates/primefield" }
 ```
 
 ## Testing


### PR DESCRIPTION
Current dependency code leads to a following error:

```
bash-3.2$ nargo compile
Unexpected workspace definition found in /Users/pavlovdog/nargo/github.com/shuklaayush/noir-bigintv0.1.0/Nargo.toml
bash-3.2$ nargo --version
nargo 0.17.0 (git version hash: 86704bad3af19dd03634cbec0d697ff8159ed683, is dirty: false)
```