### PR TITLE
Limit input for _to_biguint56_ in _primefield_

### DIFF
--- a/crates/primefield/src/lib.nr
+++ b/crates/primefield/src/lib.nr
@@ -97,6 +97,8 @@ impl PrimeField {
 
     /// Converts the prime field element to a BigUint56 value.
     fn to_biguint56(self: Self) -> BigUint56 {
+        assert(self.val.lt(Self::modulus()));
+
         // Turn into canonical form by computing
         // (a.R) / R = a
         let tmp = PrimeField::montgomery_reduce(self.val, BigUint56::zero());


### PR DESCRIPTION
Could you review this one, pls. Am I correct that starting from the modulus `val` this function starts to produce nonsense?