### PR TITLE
`primefield::neg` doesn't account for Montgomery form

### DIFF
--- a/crates/curves/src/ecdsa_secp256k1/fp.nr
+++ b/crates/curves/src/ecdsa_secp256k1/fp.nr
@@ -117,7 +117,7 @@ impl PrimeField {
         } else {
             // Subtract `self` from `MODULUS` to negate
             let modulus = PrimeField::modulus().val;
-            Self { val: modulus.sub(self.val) }
+            PrimeField::from_biguint56(modulus.sub(self.to_biguint56()))
         }
     }
 

--- a/crates/primefield/src/lib.nr
+++ b/crates/primefield/src/lib.nr
@@ -137,7 +137,7 @@ impl PrimeField {
         } else {
             // Subtract `self` from `MODULUS` to negate
             let modulus = PrimeField::modulus().val;
-            Self { val: modulus.sub(self.val) }
+            PrimeField::from_biguint56(modulus.sub(self.to_biguint56()))
         }
     }
 


### PR DESCRIPTION
This one is more like a concrete issue than real PR; just something to start with...